### PR TITLE
fix: Uncaught SyntaxError: Unexpected token var bug

### DIFF
--- a/resources/views/livewire/livewire-quill.blade.php
+++ b/resources/views/livewire/livewire-quill.blade.php
@@ -16,7 +16,7 @@
 
     @script
     <script>
-        var quillContainer = null;
+        let quillContainer = null;
 
         function initQuill(id, data, placeholder, toolbar) {
             var content = null;


### PR DESCRIPTION
<img width="652" height="270" alt="Screenshot from 2026-02-16 11-07-56" src="https://github.com/user-attachments/assets/5e914f94-d621-4452-a3ad-cc8d7471c321" />

This error happened after the last update when trying to access the component via page reload.