### PR TITLE
fix: Uncaught TypeError, Cannot read properties of undefined (dispatch)

### DIFF
--- a/resources/views/livewire/livewire-quill.blade.php
+++ b/resources/views/livewire/livewire-quill.blade.php
@@ -119,7 +119,7 @@
                 // set a timeout to see if the user is still typing
                 quillContainer = setTimeout(function() {
                     // set the content to the model
-                    @this.dispatch('contentChanged', {
+                    Livewire.dispatch('contentChanged', {
                         editorId: content.container.id,
                         content: content.root.innerHTML
                     })


### PR DESCRIPTION
`Uncaught TypeError: Cannot read properties of undefined (reading 'dispatch') at eval (eval at safeAsyncFunction (livewire.js?id=40a765a4:1192:21), <anonymous>:106:65)`

Fixed This error that happens while trying to navigate using `wire:navigate` between pages (not full-page components) with latest version of livewire 3.7.

The editor was loaded successfully at the last version 5.1.1 while even navigating, but the content would not be changed after the navigation because of this bug.