### PR TITLE
feat: add lazy prop to defer content sync until blur

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Use it in any Livewire component like so:
         ['image'],
     ],
     'mergeToolbar' => true, // optional, if you want to merge the toolbar with the default toolbar configuration
+    'lazy' => false, // optional, if true the editor will only sync content to the server on blur instead of every keystroke
 ])
 ```
 
@@ -176,6 +177,19 @@ An array of arrays to manage and create a toolbar for Quill to use
 If you want to merge the toolbar with the default toolbar configuration (i.e the one set in the config file) then set this to true.
 
 If you set this to false, the toolbar will be replaced with the one you provide.
+
+### Lazy
+
+By default, the editor syncs content to the server on every keystroke (debounced at 500ms). If you'd prefer to only sync when the user finishes editing and leaves the editor, set `lazy` to `true`:
+
+```php
+@livewire('livewire-quill', [
+    'quillId' => 'myEditor',
+    'lazy' => true,
+])
+```
+
+This is useful when you don't want the overhead of frequent server round-trips, such as in forms where the content only needs to be available on submit.
 
 ## Initialising Livewire Quill Manually
 

--- a/resources/views/livewire/livewire-quill.blade.php
+++ b/resources/views/livewire/livewire-quill.blade.php
@@ -85,6 +85,7 @@
                 if (source === "user") {
                     let currrentContents = content.getContents();
                     let diff = currrentContents.diff(oldDelta);
+                    let imageDeleted = false;
                     try {
                         // loop through diff.ops to find image
                         diff.ops.forEach((op) => {
@@ -95,12 +96,22 @@
 
                                     if (imageUrl) {
                                         @this.deleteImage(imageUrl);
+                                        imageDeleted = true;
                                     }
                                 }
                             }
                         });
                     } catch (_error) {
 
+                    }
+
+                    // in lazy mode, sync content immediately when an image is deleted
+                    // so the parent model doesn't retain a broken image reference
+                    if (lazy && imageDeleted) {
+                        Livewire.dispatch('contentChanged', {
+                            editorId: content.container.id,
+                            content: content.root.innerHTML
+                        });
                     }
                 }
             });
@@ -109,11 +120,16 @@
 
             // on content change
             if (lazy) {
-                content.root.addEventListener('blur', function() {
-                    if (init) {
+                var initialContent = content.root.innerHTML;
+                content.container.addEventListener('focusout', function(e) {
+                    // ignore focus moving within the editor (e.g. toolbar button clicks)
+                    if (content.container.contains(e.relatedTarget)) {
                         return;
                     }
-
+                    // only dispatch if content actually changed
+                    if (content.root.innerHTML === initialContent) {
+                        return;
+                    }
                     Livewire.dispatch('contentChanged', {
                         editorId: content.container.id,
                         content: content.root.innerHTML

--- a/resources/views/livewire/livewire-quill.blade.php
+++ b/resources/views/livewire/livewire-quill.blade.php
@@ -18,7 +18,7 @@
     <script>
         let quillContainer = null;
 
-        function initQuill(id, data, placeholder, toolbar) {
+        function initQuill(id, data, placeholder, toolbar, lazy) {
             var content = null;
             var init = true;
 
@@ -108,23 +108,36 @@
             content.root.innerHTML = data;
 
             // on content change
-            content.on("text-change", function(delta, oldDelta, source) {
-                if (init) {
-                    return;
-                }
+            if (lazy) {
+                content.root.addEventListener('blur', function() {
+                    if (init) {
+                        return;
+                    }
 
-                // debounce it
-                clearTimeout(quillContainer);
-
-                // set a timeout to see if the user is still typing
-                quillContainer = setTimeout(function() {
-                    // set the content to the model
                     Livewire.dispatch('contentChanged', {
                         editorId: content.container.id,
                         content: content.root.innerHTML
-                    })
-                }, 500);
-            });
+                    });
+                });
+            } else {
+                content.on("text-change", function(delta, oldDelta, source) {
+                    if (init) {
+                        return;
+                    }
+
+                    // debounce it
+                    clearTimeout(quillContainer);
+
+                    // set a timeout to see if the user is still typing
+                    quillContainer = setTimeout(function() {
+                        // set the content to the model
+                        Livewire.dispatch('contentChanged', {
+                            editorId: content.container.id,
+                            content: content.root.innerHTML
+                        })
+                    }, 500);
+                });
+            }
 
             init = false;
         }
@@ -135,7 +148,7 @@
             var quillContainer = document.getElementById(event.quillId);
 
             if (!quillContainer.dataset.initialized) {
-                initQuill(event.quillId, event.data, event.placeholder, event.toolbar);
+                initQuill(event.quillId, event.data, event.placeholder, event.toolbar, event.lazy);
                 quillContainer.dataset.initialized = true;
             }
         });

--- a/src/Http/Livewire/LivewireQuill.php
+++ b/src/Http/Livewire/LivewireQuill.php
@@ -20,6 +20,7 @@ class LivewireQuill extends Component
     public $placeholder;
 
     public $mergeToolbar = true;
+    public $lazy = false;
 
     // vendor
     public $quillImages;
@@ -32,12 +33,14 @@ class LivewireQuill extends Component
         $placeholder = null,
         $classes = '',
         $toolbar = [],
-        $mergeToolbar = true
+        $mergeToolbar = true,
+        $lazy = false
     ) {
         $this->quillId = $quillId;
         $this->data = $data;
         $this->placeholder = $placeholder;
         $this->classes = $classes;
+        $this->lazy = $lazy;
         $this->toolbar = $mergeToolbar ? array_merge(
             config('livewire-quill.toolbar'),
             $toolbar
@@ -76,6 +79,7 @@ class LivewireQuill extends Component
                 'placeholder' => $this->placeholder,
                 'classes' => $this->classes,
                 'toolbar' => $this->toolbar,
+                'lazy' => $this->lazy,
             ]);
         }
 

--- a/tests/Feature/BaseTest.php
+++ b/tests/Feature/BaseTest.php
@@ -68,6 +68,18 @@ it('mounts with lazy true when passed', function () {
         ->assertSet('lazy', true);
 });
 
+it('includes lazy flag in the init event payload', function () {
+    $component = Livewire::test(LivewireQuill::class, ['quillId' => 'lazyQuill', 'lazy' => true]);
+
+    // Reset rendered so the event fires again during the next Livewire lifecycle,
+    // where effects (dispatched events) are captured and assertable.
+    // Livewire passes ($eventName, $params) to the assertDispatched callback.
+    $component->set('rendered', false)
+        ->assertDispatched('livewire-quill:init', function ($name, $params) {
+            return ($params[0]['lazy'] ?? false) === true;
+        });
+});
+
 it('renders the correct view', function () {
     $component = Livewire::test(LivewireQuill::class, ['quillId' => 'renderQuill']);
     $component->assertViewIs('livewire-quill::livewire.livewire-quill');

--- a/tests/Feature/BaseTest.php
+++ b/tests/Feature/BaseTest.php
@@ -58,6 +58,16 @@ it('mounts the component with custom values', function () {
         ->assertSet('toolbar', [['bold', 'italic']]);
 });
 
+it('mounts with lazy false by default', function () {
+    Livewire::test(LivewireQuill::class, ['quillId' => 'lazyQuill'])
+        ->assertSet('lazy', false);
+});
+
+it('mounts with lazy true when passed', function () {
+    Livewire::test(LivewireQuill::class, ['quillId' => 'lazyQuill', 'lazy' => true])
+        ->assertSet('lazy', true);
+});
+
 it('renders the correct view', function () {
     $component = Livewire::test(LivewireQuill::class, ['quillId' => 'renderQuill']);
     $component->assertViewIs('livewire-quill::livewire.livewire-quill');


### PR DESCRIPTION
Closes #28

## Summary

- Adds a `lazy` boolean prop to the `livewire-quill` component. When `true`, `contentChanged` is only dispatched when the editor loses focus rather than on every keystroke (debounced at 500ms)
- Fixes toolbar-click false triggers: uses `focusout` on the Quill container with a `relatedTarget` check so clicking Bold/Italic doesn't fire a premature dispatch with pre-format HTML
- Adds a dirty check so blurring without making any edits does not dispatch `contentChanged`
- Dispatches `contentChanged` immediately on image deletion in lazy mode to keep the parent model consistent with server-side file state
- Adds tests covering default and explicit `lazy` prop values, and verifies the flag is present in the `livewire-quill:init` browser event payload

## Usage

```php
@livewire('livewire-quill', [
    'quillId' => 'myEditor',
    'lazy' => true,
])
```
