### PR TITLE
feat: add Livewire v4 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,13 +8,18 @@ on:
 
 jobs:
   tests:
-    name: Tests
+    name: "PHP ${{ matrix.php }} - Livewire ${{ matrix.livewire }}"
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.2', '8.3', '8.4', '8.5']
+        php: ["8.2", "8.3", "8.4", "8.5"]
+        livewire: ["3", "4"]
         stability: [prefer-stable]
+        exclude:
+          # pest-plugin-livewire v4 requires PHP ^8.3
+          - php: "8.2"
+            livewire: "4"
 
     steps:
       - name: Checkout code
@@ -28,12 +33,15 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      - name: Require Livewire version
+        run: composer require "livewire/livewire:^${{ matrix.livewire }}.0" --no-update --no-interaction
+
       - name: Install dependencies
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress ${{ matrix.flags }}
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/pest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ["8.2", "8.3", "8.4", "8.5"]
+        php: ["8.2", "8.3", "8.4"]
         livewire: ["3", "4"]
         stability: [prefer-stable]
+        include:
+          # PHP 8.5 is only tested against Livewire 4
+          - php: "8.5"
+            livewire: "4"
+            stability: prefer-stable
         exclude:
           # pest-plugin-livewire v4 requires PHP ^8.3
           - php: "8.2"
@@ -48,4 +53,4 @@ jobs:
           command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/pest
+        run: vendor/bin/pest --no-coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,10 @@ jobs:
       - name: Require Livewire version
         run: composer require "livewire/livewire:^${{ matrix.livewire }}.0" --no-update --no-interaction
 
+      - name: Require Pest v4 for Livewire 4 runs
+        if: matrix.livewire == '4'
+        run: composer require "pestphp/pest:^4.0" "pestphp/pest-plugin-livewire:^4.0" --no-update --no-interaction --dev
+
       - name: Install dependencies
         uses: nick-fields/retry@v3
         with:

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     "require-dev": {
         "laravel/pint": "^1.17",
         "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
-        "pestphp/pest": "^3.0|^4.0",
-        "pestphp/pest-plugin-livewire": "^3.0|^4.0"
+        "pestphp/pest": "^3.0",
+        "pestphp/pest-plugin-livewire": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,66 +1,66 @@
 {
-  "name": "joelwmale/livewire-quill",
-  "version": "5.3.0",
-  "description": "Easily add QuillJS with image support to any Laravel Livewire component.",
-  "keywords": [
-    "joelwmale",
-    "laravel",
-    "livewire-quill"
-  ],
-  "homepage": "https://github.com/joelwmale/livewire-quill",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Joel Male",
-      "email": "joel@joelmale.com",
-      "role": "Developer"
-    }
-  ],
-  "require": {
-    "php": "^8.1|^8.2|^8.3|^8.4|^8.5",
-    "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
-    "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0",
-    "livewire/livewire": "^3.0"
-  },
-  "require-dev": {
-    "laravel/pint": "^1.17",
-    "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
-    "pestphp/pest": "^3.0",
-    "pestphp/pest-plugin-livewire": "^3.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "Joelwmale\\LivewireQuill\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Joelwmale\\LivewireQuill\\Tests\\": "tests/"
-    }
-  },
-  "scripts": {
-    "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
-    "test": "vendor/bin/pest",
-    "test-coverage": "vendor/bin/pest --coverage",
-    "format": "vendor/bin/pint"
-  },
-  "config": {
-    "sort-packages": true,
-    "allow-plugins": {
-      "pestphp/pest-plugin": true,
-      "phpstan/extension-installer": true
-    }
-  },
-  "extra": {
-    "laravel": {
-      "providers": [
-        "Joelwmale\\LivewireQuill\\LivewireQuillServiceProvider"
-      ],
-      "aliases": {
-        "LivewireQuill": "Joelmale\\LivewireQuill\\Facades\\LivewireQuill"
-      }
-    }
-  },
-  "minimum-stability": "dev",
-  "prefer-stable": true
+    "name": "joelwmale/livewire-quill",
+    "version": "5.4.0",
+    "description": "Easily add QuillJS with image support to any Laravel Livewire component.",
+    "keywords": [
+        "joelwmale",
+        "laravel",
+        "livewire-quill"
+    ],
+    "homepage": "https://github.com/joelwmale/livewire-quill",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Joel Male",
+            "email": "joel@joelmale.com",
+            "role": "Developer"
+        }
+    ],
+    "require": {
+        "php": "^8.1|^8.2|^8.3|^8.4|^8.5",
+        "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0",
+        "livewire/livewire": "^3.0|^4.0"
+    },
+    "require-dev": {
+        "laravel/pint": "^1.17",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "pestphp/pest": "^3.0|^4.0",
+        "pestphp/pest-plugin-livewire": "^3.0|^4.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Joelwmale\\LivewireQuill\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Joelwmale\\LivewireQuill\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
+        "test": "vendor/bin/pest",
+        "test-coverage": "vendor/bin/pest --coverage",
+        "format": "vendor/bin/pint"
+    },
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true,
+            "phpstan/extension-installer": true
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Joelwmale\\LivewireQuill\\LivewireQuillServiceProvider"
+            ],
+            "aliases": {
+                "LivewireQuill": "Joelmale\\LivewireQuill\\Facades\\LivewireQuill"
+            }
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "scripts": {
         "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
-        "test": "vendor/bin/pest",
+        "test": "vendor/bin/pest --no-coverage",
         "test-coverage": "vendor/bin/pest --coverage",
         "format": "vendor/bin/pint"
     },


### PR DESCRIPTION
Closes #36

## Summary

- Widens `livewire/livewire` constraint to `^3.0|^4.0`
- Widens `pestphp/pest` and `pestphp/pest-plugin-livewire` to `^3.0|^4.0`
- Updates CI matrix to test against both Livewire 3 and 4
- Bumps version to 5.4.0

No code changes required - the component, blade view, trait, and service provider are all compatible with Livewire v4 as-is.

## Notes

- PHP 8.2 is excluded from the Livewire 4 CI matrix because `pest-plugin-livewire` v4 requires PHP `^8.3`. The package itself still supports PHP 8.1+ at runtime with Livewire 4.
- Existing Livewire 3 users are unaffected.

## Test plan

- [ ] All existing tests pass (`composer test`)
- [ ] CI passes for both Livewire 3 and 4 matrix entries